### PR TITLE
Improve missing API key handling

### DIFF
--- a/src/components/GameGenerator.tsx
+++ b/src/components/GameGenerator.tsx
@@ -144,13 +144,14 @@ export const GameGenerator = () => {
         body: JSON.stringify(formData)
       });
 
+      const responseData = await response.json();
+
       if (!response.ok) {
-        const errorText = await response.text();
-        console.error('❌ Erreur lors de l\'appel API:', errorText);
-        throw new Error(errorText);
+        console.error('❌ Erreur lors de l\'appel API:', responseData);
+        throw new Error(responseData.error || 'Erreur inconnue');
       }
 
-      const data = await response.json();
+      const data = responseData;
 
       console.log('✅ Réponse API reçue:', data);
       console.log('✅ API called successfully');
@@ -177,9 +178,10 @@ export const GameGenerator = () => {
 
     } catch (error) {
       console.error('❌ Erreur lors de la génération:', error);
+      const message = error instanceof Error ? error.message : 'Erreur inconnue';
       toast({
         title: 'Erreur',
-        description: 'Impossible de générer le jeu. Vérifiez la console pour plus de détails.',
+        description: message,
         variant: 'destructive',
       })
     } finally {

--- a/supabase/functions/generate-game/index.ts
+++ b/supabase/functions/generate-game/index.ts
@@ -17,7 +17,10 @@ serve(async (req) => {
     const apiKey = Deno.env.get('GAME_GENERATION_API_KEY');
 
     if (!apiKey) {
-      throw new Error('API key not configured');
+      return new Response(JSON.stringify({ error: 'Clé API manquante' }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
     }
 
     console.log('🚀 API Key found, starting game generation...');


### PR DESCRIPTION
## Summary
- handle missing `GAME_GENERATION_API_KEY` in the Supabase `generate-game` function
- surface backend error messages in the game generator UI

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685beecdcd9c832aaef7ad9039e6cf4e